### PR TITLE
Update mysql migration version files for compatibility with mysql 5.7.8 and add `multi_step_best_predictions` column to bring up to date with latest htmengine.

### DIFF
--- a/repository/migrations/versions/000_57ab75d58038_initial_htmengine.py
+++ b/repository/migrations/versions/000_57ab75d58038_initial_htmengine.py
@@ -43,7 +43,7 @@ def upgrade():
   op.create_table('instance_status_history',
     sa.Column('server', sa.VARCHAR(length=100), server_default='',
               nullable=False),
-    sa.Column('timestamp', sa.TIMESTAMP(), server_default='0000-00-00 00:00:00',
+    sa.Column('timestamp', sa.TIMESTAMP(), server_default=None,
               nullable=False),
     sa.Column('status', sa.VARCHAR(length=32), server_default='',
               nullable=False),

--- a/repository/migrations/versions/002_872a895b8e8_fix_datetime_and_timestamp_defaults.py
+++ b/repository/migrations/versions/002_872a895b8e8_fix_datetime_and_timestamp_defaults.py
@@ -19,11 +19,11 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-"""timestatmp to datetime
+"""fix DATETIME and TIMESTAMP defaults
 
-Revision ID: 1d2eddc43366
-Revises: 57ab75d58038
-Create Date: 2014-12-30 15:58:52.062058
+Revision ID: 872a895b8e8
+Revises: 1d2eddc43366
+Create Date: 2016-05-11 18:42:24.861060
 """
 
 from alembic import op
@@ -31,30 +31,22 @@ import sqlalchemy as sa
 
 
 # Revision identifiers, used by Alembic. Do not change.
-revision = '1d2eddc43366'
-down_revision = '57ab75d58038'
+revision = '872a895b8e8'
+down_revision = '1d2eddc43366'
 
 
 
 def upgrade():
-  """ Change tables to use DATETIME column types instead of TIMESTAMP """
-  # Change tables to use DATETIME column types instead of TIMESTAMP
-  op.alter_column("instance_status_history", "timestamp",
-                  type_=sa.DATETIME,
-                  server_default=None,
-                  existing_nullable=False)
-
-  op.alter_column("metric", "last_timestamp",
-                  type_=sa.DATETIME,
-                  existing_nullable=True,
-                  existing_server_default=sa.text("NULL"))
-
-  op.alter_column("metric_data", "timestamp",
-                  type_=sa.DATETIME,
-                  existing_nullable=False)
-  ### end Alembic commands ###
+    """Fix server defaults for DATETIME columns, because
+    0 ("0000-00-00 00:00:00") is deprecated as default for those colum types
+    as of mysql 5.7.8, and will fail with mysql installed with default config.
+    """
+    op.alter_column("instance_status_history", "timestamp",
+                    server_default=None,
+                    existing_type=sa.DATETIME,
+                    existing_nullable=False)
 
 
 
 def downgrade():
-  raise NotImplementedError("Rollback is not supported.")
+    raise NotImplementedError("Rollback is not supported.")

--- a/repository/migrations/versions/003_315d6ad6c19f_adding_multistep_best_predictions_column.py
+++ b/repository/migrations/versions/003_315d6ad6c19f_adding_multistep_best_predictions_column.py
@@ -19,11 +19,11 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-"""timestatmp to datetime
+"""Adding multi_step_best_predictions column to metric_data table.
 
-Revision ID: 1d2eddc43366
-Revises: 57ab75d58038
-Create Date: 2014-12-30 15:58:52.062058
+Revision ID: 315d6ad6c19f
+Revises: 872a895b8e8
+Create Date: 2016-08-06 14:10:52.521030
 """
 
 from alembic import op
@@ -31,28 +31,15 @@ import sqlalchemy as sa
 
 
 # Revision identifiers, used by Alembic. Do not change.
-revision = '1d2eddc43366'
-down_revision = '57ab75d58038'
+revision = '315d6ad6c19f'
+down_revision = '872a895b8e8'
 
 
 
 def upgrade():
-  """ Change tables to use DATETIME column types instead of TIMESTAMP """
-  # Change tables to use DATETIME column types instead of TIMESTAMP
-  op.alter_column("instance_status_history", "timestamp",
-                  type_=sa.DATETIME,
-                  server_default=None,
-                  existing_nullable=False)
-
-  op.alter_column("metric", "last_timestamp",
-                  type_=sa.DATETIME,
-                  existing_nullable=True,
-                  existing_server_default=sa.text("NULL"))
-
-  op.alter_column("metric_data", "timestamp",
-                  type_=sa.DATETIME,
-                  existing_nullable=False)
-  ### end Alembic commands ###
+    """ Adds column 'multi_step_best_predictions' to metric_data table """
+    op.add_column('metric_data', sa.Column('multi_step_best_predictions',
+                                           sa.TEXT(), nullable=True))
 
 
 


### PR DESCRIPTION
Fixes #13
Got the new content from https://github.com/numenta/numenta-apps/tree/master/htmengine/tests/support/skeleton-app/migrations/versions
